### PR TITLE
Update bazel-0.15.0.bazelrc

### DIFF
--- a/bazelrc/bazel-0.15.0.bazelrc
+++ b/bazelrc/bazel-0.15.0.bazelrc
@@ -132,7 +132,7 @@ build:remote-cache --tls_enabled=true
 build:remote-cache --experimental_strict_action_env=true
 build:remote-cache --remote_timeout=3600
 build:remote-cache --auth_enabled=true
-build:remote-cache --spawn_strategy=remote
-build:remote-cache --strategy=Javac=remote
-build:remote-cache --strategy=Closure=remote
-build:remote-cache --genrule_strategy=remote
+build:remote-cache --spawn_strategy=standalone
+build:remote-cache --strategy=Javac=standalone
+build:remote-cache --strategy=Closure=standalone
+build:remote-cache --genrule_strategy=standalone


### PR DESCRIPTION
Change strategy flags from "remote" to "standalone" for compliance with newer versions of Bazel